### PR TITLE
Update env.sh

### DIFF
--- a/services/geoserver/env.sh
+++ b/services/geoserver/env.sh
@@ -8,5 +8,5 @@ export SERVICE_PATH="/${SERVICE_NAME}"
 
 # Can be usually left as-is, unless you want to run specific build and/or version.
 export DOCKER_IMAGE_NAME="oscarfonts/geoserver"
-export DOCKER_IMAGE_VERSION="latest"
+export DOCKER_IMAGE_VERSION="2.19.5"
 export DOCKER_IMAGE="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_VERSION}"


### PR DESCRIPTION
Set fixed image version tag to 2.19.5 in order to fix a Java missing class issue:
java.lang.NoSuchMethodError: 'void org.apache.commons.logging.LogFactory.release(java.lang.ClassLoader)'